### PR TITLE
Set `sh_word_split` option

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -22,6 +22,7 @@ WORDCHARS=''
 
 # Configure shell behaviour to be more like bash on Linux
 setopt sh_nullcmd
+setopt sh_word_split
 setopt bash_auto_list
 unsetopt auto_menu
 unsetopt always_last_prompt


### PR DESCRIPTION
This pull request includes a small change to the `.zshrc` file. The change configures the shell behavior to include the `sh_word_split` option, which makes the shell behavior more like bash on Linux.

* [`.zshrc`](diffhunk://#diff-4c2d312ff50ee6b26c2cb601fc96a95eceabe4b456831762e5d6caf41b900383R25): Added the `sh_word_split` option to configure shell behavior.